### PR TITLE
Update demonstration command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ There are three ways to get `httpstat`:
 Just pass a url with it:
 
 ```bash
-python httpstat.py httpbin.org/get
+python -m httpstat httpbin.org/get
 ```
 
 By default it will write response body in a tempfile, but you can let it print out by setting `HTTPSTAT_SHOW_BODY=true`:
 
 ```bash
-HTTPSTAT_SHOW_BODY=true python httpstat.py httpbin.org/get
+HTTPSTAT_SHOW_BODY=true python -m httpstat httpbin.org/get
 ```
 
 You can pass any curl supported arguments after the url (except for `-w`, `-D`, `-o`, `-s`, `-S` which are already used by httpstat):
 
 ```bash
-HTTPSTAT_SHOW_BODY=true python httpstat.py httpbin.org/post -X POST --data-urlencode "a=中文" -v
+HTTPSTAT_SHOW_BODY=true python -m httpstat httpbin.org/post -X POST --data-urlencode "a=中文" -v
 ```


### PR DESCRIPTION
Using module invoking by default instead of running script cause httpstat.py not in env PATH when installed by pip.
